### PR TITLE
Made easier to read the two test examples provided

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -16,6 +16,7 @@ contributors:
   - yairhaimo
   - farskid
   - LukeMwila
+  - Jalitha
 ---
 
 At its core, __webpack__ is a _static module bundler_ for modern JavaScript applications. When webpack processes your application, it internally builds a [dependency graph](/concepts/dependency-graph/) which maps every module your project needs and generates one or more _bundles_.
@@ -118,7 +119,7 @@ The configuration above has defined a `rules` property for a single module with 
 
 W> It is important to remember that when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`. For your benefit, webpack will warn you if this is done incorrectly.
 
-W> Keep in mind that when using regex to match files, you may not quote it. i.e `/\.txt$/` is not the same as `'/\.txt$/'`/ `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the latter instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
+W> Keep in mind that when using regex to match files, you may not quote it. i.e `/\.txt$/` is not the same as `'/\.txt$/'` nor the same as `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the latter instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
 
 You can check further customization when including loaders in the [loaders section](/concepts/loaders).
 

--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -119,7 +119,7 @@ The configuration above has defined a `rules` property for a single module with 
 
 W> It is important to remember that when defining rules in your webpack config, you are defining them under `module.rules` and not `rules`. For your benefit, webpack will warn you if this is done incorrectly.
 
-W> Keep in mind that when using regex to match files, you may not quote it. i.e `/\.txt$/` is not the same as `'/\.txt$/'` nor the same as `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the latter instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
+W> Keep in mind that when using regex to match files, you may not quote it. i.e `/\.txt$/` is not the same as `'/\.txt$/'` or `"/\.txt$/"`. The former instructs webpack to match any file that ends with .txt and the latter instructs webpack to match a single file with an absolute path '.txt'; this is likely not your intention. 
 
 You can check further customization when including loaders in the [loaders section](/concepts/loaders).
 


### PR DESCRIPTION
The forward slash in between the two regex examples is hard to spot when the examples are using a few slashes as well.